### PR TITLE
feat(nginx): 调整客户端最大请求体大小和缓冲区大小

### DIFF
--- a/mutil_models/nginx.conf
+++ b/mutil_models/nginx.conf
@@ -22,6 +22,8 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
+    client_max_body_size 100M;
+    client_body_buffer_size 100M;
 
     # 定义上游服务器
     upstream chat_generate_reason {


### PR DESCRIPTION
- 设置 client_max_body_size 为 100M，允许更大的请求体
- 设置 client_body_buffer_size 为 100M，增加请求体缓冲区大小
- 
fixes #1 